### PR TITLE
Update string matching for conversion to REST

### DIFF
--- a/yml_utils.py
+++ b/yml_utils.py
@@ -80,7 +80,7 @@ def sortAdvisories(advisories):
             yield a
 
 def bugLinkToRest(link):
-    return link.replace("/buglist.cgi?query_format=advanced", "/rest/bug?")
+    return link.replace("/buglist.cgi?", "/rest/bug?")
 
 def doBugRequest(link):
     r = requests.get(bugLinkToRest(link))


### PR DESCRIPTION
Commit https://github.com/tomrittervg/secadv/commit/df2d3c866e7ef09b64aa0118af761ca3db9d17b3 broke YML generation by removing `query_format=advanced` from all URLs.  This PR updates the string match for converting a URL to REST.