### PR TITLE
Use getPriorVersion everywhere rather than float math.

### DIFF
--- a/gen_queries.py
+++ b/gen_queries.py
@@ -36,7 +36,7 @@ def versionToESRs(version):
 
 def getPriorVersion(version):
     if "." in version:
-        return version.split(".")[0] + str(int(version.split(".")[1])-1)
+        return f'{version.split(".")[0]}.{int(version.split(".")[1]) - 1}'
     else:
         return str(int(version) - 1)
 
@@ -73,7 +73,7 @@ def toAssign(version, primaryVersion, esr):
     else:
         return toAssignMain(version)
 def toAssignMain(version):
-    prior = getPriorVersion(version)
+    prior = getPriorVersion(version).replace(".", "")
     return "https://bugzilla.mozilla.org/buglist.cgi?" + \
     \
     "&f2=cf_status_firefox" + prior + "&o2=nowords&v2=fixed%20verified%20disabled%20unaffected" + \
@@ -88,7 +88,7 @@ def toAssignMain(version):
     "&f14=CP"
 
 def toAssignESR(esrVersion, primaryVersion):
-    esrBaseVersion = str(int(float(esrVersion)))
+    esrBaseVersion = esrVersion.split(".")[0]
     return "https://bugzilla.mozilla.org/buglist.cgi?" + \
     \
     "&f2=cf_tracking_firefox_esr" + esrBaseVersion + "&o2=equals&v2=" + primaryVersion + "%2B" + \
@@ -108,7 +108,7 @@ def toWrite(version, primaryVersion, esr):
     else:
         return toWriteMain(version)
 def toWriteMain(version):
-    prior = getPriorVersion(version)
+    prior = getPriorVersion(version).replace(".", "")
     return "https://bugzilla.mozilla.org/buglist.cgi?" + \
     \
     "&f2=cf_status_firefox" + prior + "&o2=nowords&v2=fixed%20verified%20disabled%20unaffected" + \
@@ -126,7 +126,7 @@ def toWriteMain(version):
     "&f18=CP"
 
 def toWriteESR(esrVersion, primaryVersion):
-    esrBaseVersion = str(int(float(esrVersion)))
+    esrBaseVersion = esrVersion.split(".")[0]
     return "https://bugzilla.mozilla.org/buglist.cgi?" + \
     \
     "&f2=cf_tracking_firefox_esr" + esrBaseVersion + "&o2=equals&v2=" + primaryVersion + "%2B" + \

--- a/gen_yml.py
+++ b/gen_yml.py
@@ -14,7 +14,7 @@ try:
 except:
     APIKEY = None
 
-from gen_queries import versionToESRs, nonRollupList, rollupListMainAndESR, rollupListMainOnly, rollupListMain, rollupListESROnly, rollupListESR
+from gen_queries import getPriorVersion, versionToESRs, nonRollupList, rollupListMainAndESR, rollupListMainOnly, rollupListMain, rollupListESROnly, rollupListESR
 from yml_utils import *
 
 if __name__ == "__main__":
@@ -210,7 +210,7 @@ if __name__ == "__main__":
     # Rollup Bug for Main + ESR. Always do this one.
     doRollups(sharedRollupBugs,
         f"Firefox {mainVersion}, Firefox ESR {esrVersion}, and Thunderbird {esrVersion}",
-        f"Firefox {str(int(mainVersion)-1)}, Firefox ESR {float(esrVersion)-.1}, and Thunderbird {float(esrVersion)-.1}")
+        f"Firefox {int(mainVersion)-1}, Firefox ESR {getPriorVersion(esrVersion)}, and Thunderbird {getPriorVersion(esrVersion)}")
     if not args.esr:
     # Rollup Bug for Main Only 
         doRollups(version_specific_rollups,
@@ -220,4 +220,4 @@ if __name__ == "__main__":
     # Rollup bug for ESR only
         doRollups(version_specific_rollups,
             f"Firefox ESR {esrVersion}",
-            f"Firefox ESR {float(esrVersion) - .1}")
+            f"Firefox ESR {getPriorVersion(esrVersion)}")


### PR DESCRIPTION
This corrects prior version listed in rollup text when ESR dot version is >=10, and should eliminate float decimal errors.