### PR TITLE
Add 128 to the list of known ESR releases

### DIFF
--- a/gen_queries.py
+++ b/gen_queries.py
@@ -14,7 +14,7 @@ It's because 68.10 is mathematically equal to 68.1 but they are different versio
 def versionToESRs(version):
     version = int(version)
 
-    knownESRs = [60, 68, 78, 91, 102, 115]
+    knownESRs = [60, 68, 78, 91, 102, 115, 128]
     twoESRVersions = []
     for x in knownESRs:
         twoESRVersions.append(x)
@@ -55,7 +55,8 @@ def sanityCheck():
         (78, ["68.10", "78.0"]),
         (79, ["68.11", "78.1"]),
         (80, ["68.12", "78.2"]),
-        (81, ["78.3"])
+        (81, ["78.3"]),
+        (129, ["115.14", "128.1"])
     ]
     for e in expected:
         if versionToESRs(e[0]) != e[1]:


### PR DESCRIPTION
Now that Firefox has started a new ESR we need to add it to gen_queries.py in order to get the correct set of advisory queries.